### PR TITLE
Speedups for the HIT Catcher

### DIFF
--- a/hit_catcher/hit_catcher.js
+++ b/hit_catcher/hit_catcher.js
@@ -526,22 +526,24 @@ async function catcherRun(forcedId) {
             const status = response.status;
 
             if (response.ok && response.url.indexOf(`tasks`) !== -1) {
-                const text = await response.text();
-                const parser = new DOMParser();
-                const doc = parser.parseFromString(text, `text/html`);
-                const json = JSON.parse(doc.querySelector(`[data-react-class="require('reactComponents/common/ShowModal')['default']"]`).dataset.reactProps);
+                if (!watcher.project) {
+                    const text = await response.text();
+                    const parser = new DOMParser();
+                    const doc = parser.parseFromString(text, `text/html`);
+                    const json = JSON.parse(doc.querySelector(`[data-react-class="require('reactComponents/common/ShowModal')['default']"]`).dataset.reactProps);
 
-                watcher.project = watcher.project ? watcher.project : {
-                    requester_name: json.modalOptions.requesterName,
-                    requester_id: json.modalOptions.contactRequesterUrl.match(/requester_id.+?=([0-9A-Z]+)/) ? json.modalOptions.contactRequesterUrl.match(/requester_id.+?=([0-9A-Z]+)/)[1] : null,
-                    title: json.modalOptions.projectTitle,
-                    hit_set_id: response.url.match(/projects\/([A-Z0-9]+)\/tasks/) ? response.url.match(/projects\/([A-Z0-9]+)\/tasks/)[1] : null,
-                    monetary_reward: {
-                        amount_in_dollars: json.modalOptions.monetaryReward.amountInDollars
-                    },
-                    assignment_duration_in_seconds: json.modalOptions.assignmentDurationInSeconds,
-                    project_requirements: [{qualification_type: { name: `Unknown` }, comparator: `Unknown`, qualification_values: [``]}]
+                    watcher.project = watcher.project ? watcher.project : {
+                        requester_name: json.modalOptions.requesterName,
+                        requester_id: json.modalOptions.contactRequesterUrl.match(/requester_id.+?=([0-9A-Z]+)/) ? json.modalOptions.contactRequesterUrl.match(/requester_id.+?=([0-9A-Z]+)/)[1] : null,
+                        title: json.modalOptions.projectTitle,
+                        hit_set_id: response.url.match(/projects\/([A-Z0-9]+)\/tasks/) ? response.url.match(/projects\/([A-Z0-9]+)\/tasks/)[1] : null,
+                        monetary_reward: {
+                            amount_in_dollars: json.modalOptions.monetaryReward.amountInDollars
+                        },
+                        assignment_duration_in_seconds: json.modalOptions.assignmentDurationInSeconds,
+                        project_requirements: [{qualification_type: { name: `Unknown` }, comparator: `Unknown`, qualification_values: [``]}]
 
+                    }
                 }
 
                 if (~response.url.indexOf(`assignment_id=`)) {

--- a/hit_catcher/hit_catcher.js
+++ b/hit_catcher/hit_catcher.js
@@ -503,6 +503,7 @@ let timer = 0;
 async function catcherRun(forcedId) {
     const start = new Date().getTime();
 
+    cacheVoice()
     function delay() {
         const nextCatch = start + storage.hitCatcher.speed;
         const adjustedDelay = nextCatch - new Date().getTime();
@@ -661,11 +662,15 @@ function catcherCaptchaFound() {
     }
 }
 
-speechSynthesis.getVoices();
+function cacheVoice(){
+    if (!('voice' in window) || voice == undefined){
+        voice = speechSynthesis.getVoices().filter((voice) => voice.name == `Google US English`)[0];
+    }
+}
 
-function textToSpeech(phrase) {
+async function textToSpeech(phrase) {
     const message = new SpeechSynthesisUtterance(phrase);
-    message.voice = speechSynthesis.getVoices().filter((voice) => voice.name == `Google US English`)[0];
+    message.voice = window.voice;
     window.speechSynthesis.speak(message);
 }
 


### PR DESCRIPTION
Tried to make the Catcher faster by caching the voice used by the TextToSpeech because it seems a bit slow to get the list of available voices every time. Also I've see a huge improvement by avoiding the parsing of the response HTML and all subsequent operations for HITs it already got the information for.

Edit: also made textToSpeech() async

Hoping this makes sense and I didn't overseen any edge case.