### PR TITLE
Cache voice in js/text-to-speech.js too since it's used by the Finder

### DIFF
--- a/js/text-to-speech.js
+++ b/js/text-to-speech.js
@@ -1,10 +1,13 @@
 /* eslint-disable no-unused-vars */
 
 function getVoice(name) {
-  const voices = speechSynthesis.getVoices();
-  const filtered = voices.filter(v => v.name === (name || v.name));
-  const voice = filtered[0] || voices[0];
-  return voice;
+  if (!window.voice) {
+    voices = speechSynthesis.getVoices();
+    const filtered = voices.filter(v => v.name === (name || v.name));
+    const voice = filtered[0] || voices[0];
+    window.voice = voice;
+  }
+  return window.voice;
 }
 
 function getSpeechVoice(name) {


### PR DESCRIPTION
Hope this stop the Finder from bogging down the machine in rapid succession of "Include list match found...", mostly I'm hopping that by caching the 'Google US English' voice it will only use the System's, which seems slow under heavy demand, text to speech as a backup. I believe it saves a few milliseconds too since the gathering of the available voices seems to be blocking.

There seems to be a fallback in case the selected voice is not available, by grabbing the first I think. The speech API seems to automatically use the System's voice if it can't use the online one. Just a thing I noticed.