### PR TITLE
Change method to check if the user is logged out

### DIFF
--- a/hit_catcher/hit_catcher.js
+++ b/hit_catcher/hit_catcher.js
@@ -517,10 +517,11 @@ async function catcherRun(forcedId) {
         const watcher = storage.watchers[id];
 
         const response = await fetch(`https://worker.mturk.com/projects/${id}/tasks/accept_random?format=json`, {
-            credentials: `include`
-        });
+            credentials: `include`,
+            redirect: `manual`
+        })
 
-        if (response.url.indexOf(`https://worker.mturk.com`) > -1) {
+        if (response.type != "opaqueredirect") {
             watcher.searched = watcher.searched > 0 ? watcher.searched + 1 : 1;
 
             const status = response.status;
@@ -560,7 +561,7 @@ async function catcherRun(forcedId) {
 
             watcherUpdate(watcher);
             catcher.timeout = setTimeout(catcherRun, delay(), status === 429 ? id : undefined);
-        } else if (response.url.indexOf(`https://www.amazon.com/ap/signin`) > -1) {
+        } else {
             return catcherLoggedOut();
         }
     }


### PR DESCRIPTION
Since it seems that _fetch()_ doesn't show the url anymore (I might be wrong about that), change the _fetch_ mode to manual and check if the response is a redirect, a "opaqueredirect", it might be good enough to know the user is logged out. This should fix #9 but might not be the best solution. 