### PR TITLE
Include a volume level slider on Hit Finder

### DIFF
--- a/hit-finder/hit-finder.css
+++ b/hit-finder/hit-finder.css
@@ -50,9 +50,32 @@
 .table-danger a:visited,
 .table-default a:visited {
     color: #551A8B !important;
+
+.range-wrapper {
+    border: solid 1px #ced4da;
+    padding: 3px 9px;
+    border-radius: .25rem;
+}
 }
 
 .table-default td {
     background-color: buttonface !important;
 }
 
+.range-wrapper {
+    border: 1px solid #ced4da;
+    border-radius: .25em;
+    padding: .2em .5em;
+}
+
+.range-wrapper input[type='range'] {
+    width: 100%;
+}
+
+.range-wrapper .lable {
+    font-size: .6em;
+}
+
+.range-wrapper .align-right {
+    float: right;
+}

--- a/hit-finder/hit-finder.html
+++ b/hit-finder/hit-finder.html
@@ -570,6 +570,13 @@
                                             <option value="sound-6">Sound 6</option>
                                         </select>
                                     </div>
+                                    <div class="col-6">
+                                        <label class="small mb-0" data-toggle="tooltip" style="cursor: help;" title="Volume level to use when speaking">Voice Sound Level</label>
+                                        <div class="range-wrapper">
+                                            <input id="volume" type="range" min="0" max="1" step=".1" />
+                                            <div class="lable"><small class="align-left">0%</small> <small class="align-right">100%</small></div>
+                                        </div>
+                                    </div>
                                 </div>
 
                                 <div class="row mb-2">

--- a/hit-finder/hit-finder.js
+++ b/hit-finder/hit-finder.js
@@ -1471,3 +1471,7 @@ document.getElementById(`hit-export-mturkcrowd`).addEventListener(`click`, (even
     });
   }
 })
+
+document.getElementById(`volume`).addEventListener(`change`, (event) => {
+    textToSpeech('Voice level test');
+});

--- a/js/text-to-speech.js
+++ b/js/text-to-speech.js
@@ -21,5 +21,6 @@ function getSpeechVoice(name) {
 async function textToSpeech(text, name) {
   const utterThis = new SpeechSynthesisUtterance(text);
   utterThis.voice = await getSpeechVoice(name);
+  utterThis.volume = document.getElementById('volume').value;
   window.speechSynthesis.speak(utterThis);
 }


### PR DESCRIPTION
I think this is a way to implement the feature requested on the issue #96, only for the Hit Finder for now. Is this a good way to implement it? The volume is not being saved. What do you think?

Can't test this on Firefox right now, it may not work the same as in Chrome.