### PR TITLE
Add HIT Catcher buttons to HIT Finder

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -72,53 +72,59 @@ chrome.storage.local.get(`version`, keys => {
   }
 });
 
+const hitFinderDefaultSettings = {
+  speed: `3000`,
+
+  "filter-search-term": ``,
+  "filter-sort": `updated_desc`,
+  "filter-page-size": `25`,
+  "filter-masters": false,
+  "filter-qualified": false,
+  "filter-min-reward": `0`,
+  "filter-min-available": `0`,
+  "filter-min-requester-rating": `0`,
+
+  "alert-new-sound": `sound-1`,
+  "alert-include-delay": `30`,
+  "alert-include-sound": `voice`,
+  "alert-pushbullet-state": `off`,
+  "alert-pushbullet-token": ``,
+
+  "display-colored-rows": true,
+
+  "display-recent-column-time": false,
+  "display-recent-column-requester": true,
+  "display-recent-column-title": true,
+  "display-recent-column-available": true,
+  "display-recent-column-reward": true,
+  "display-recent-column-masters": true,
+  "display-recent-column-hit-catcher": true,
+
+  "display-logged-column-time": true,
+  "display-logged-column-requester": true,
+  "display-logged-column-title": true,
+  "display-logged-column-available": true,
+  "display-logged-column-reward": true,
+  "display-logged-column-masters": true,
+  "display-logged-column-hit-catcher": true,
+
+  "display-included-column-time": true,
+  "display-included-column-requester": true,
+  "display-included-column-title": true,
+  "display-included-column-available": true,
+  "display-included-column-reward": true,
+  "display-included-column-masters": true,
+  "display-included-column-hit-catcher": true
+};
+
 chrome.storage.local.get(`hitFinder`, keys => {
   if (!keys.hitFinder) {
     chrome.storage.local.set({
-      hitFinder: {
-        speed: `3000`,
-
-        "filter-search-term": ``,
-        "filter-sort": `updated_desc`,
-        "filter-page-size": `25`,
-        "filter-masters": false,
-        "filter-qualified": false,
-        "filter-min-reward": `0`,
-        "filter-min-available": `0`,
-        "filter-min-requester-rating": `0`,
-
-        "alert-new-sound": `sound-1`,
-        "alert-include-delay": `30`,
-        "alert-include-sound": `voice`,
-        "alert-pushbullet-state": `off`,
-        "alert-pushbullet-token": ``,
-
-        "display-colored-rows": true,
-
-        "display-recent-column-time": false,
-        "display-recent-column-requester": true,
-        "display-recent-column-title": true,
-        "display-recent-column-available": true,
-        "display-recent-column-reward": true,
-        "display-recent-column-masters": true,
-        "display-recent-column-hit-catcher": true,
-
-        "display-logged-column-time": true,
-        "display-logged-column-requester": true,
-        "display-logged-column-title": true,
-        "display-logged-column-available": true,
-        "display-logged-column-reward": true,
-        "display-logged-column-masters": true,
-        "display-logged-column-hit-catcher": true,
-
-        "display-included-column-time": true,
-        "display-included-column-requester": true,
-        "display-included-column-title": true,
-        "display-included-column-available": true,
-        "display-included-column-reward": true,
-        "display-included-column-masters": true,
-        "display-included-column-hit-catcher": true
-      }
+      hitFinder: hitFinderDefaultSettings
+    });
+  } else {
+    chrome.storage.local.set({
+      hitFinder: { ...hitFinderDefaultSettings, ...keys.hitFinder }
     });
   }
 });

--- a/background/background.js
+++ b/background/background.js
@@ -101,6 +101,7 @@ chrome.storage.local.get(`hitFinder`, keys => {
         "display-recent-column-available": true,
         "display-recent-column-reward": true,
         "display-recent-column-masters": true,
+        "display-recent-column-hit-catcher": true,
 
         "display-logged-column-time": true,
         "display-logged-column-requester": true,
@@ -108,13 +109,15 @@ chrome.storage.local.get(`hitFinder`, keys => {
         "display-logged-column-available": true,
         "display-logged-column-reward": true,
         "display-logged-column-masters": true,
+        "display-logged-column-hit-catcher": true,
 
         "display-included-column-time": true,
         "display-included-column-requester": true,
         "display-included-column-title": true,
         "display-included-column-available": true,
         "display-included-column-reward": true,
-        "display-included-column-masters": true
+        "display-included-column-masters": true,
+        "display-included-column-hit-catcher": true
       }
     });
   }

--- a/hit-finder/hit-finder.css
+++ b/hit-finder/hit-finder.css
@@ -56,6 +56,10 @@
     background-color: buttonface !important;
 }
 
+.hit-catcher {
+    font-family: "Lucida Console", Monaco, monospace;
+}
+
 .btn-turkerview {
     background
 }

--- a/hit-finder/hit-finder.html
+++ b/hit-finder/hit-finder.html
@@ -58,6 +58,7 @@
                     <th class="text-center w-1">HITs</th>
                     <th class="text-center">Accept</th>
                     <th class="text-center w-1">M</th>
+                    <th class="text-center w-1">HC</th>
                 </thead>
                 <tbody id="include-list-hits-tbody"></tbody>
             </table>
@@ -88,6 +89,7 @@
                     <th class="text-center w-1">HITs</th>
                     <th class="text-center">Accept</th>
                     <th class="text-center w-1">M</th>
+                    <th class="text-center w-1">HC</th>
                 </thead>
                 <tbody id="recent-hits-tbody"></tbody>
             </table>
@@ -118,6 +120,7 @@
                     <th class="text-center w-1">HITs</th>
                     <th class="text-center">Accept</th>
                     <th class="text-center w-1">M</th>
+                    <th class="text-center w-1">HC</th>
                 </thead>
                 <tbody id="logged-hits-tbody"></tbody>
             </table>
@@ -716,6 +719,14 @@
                                             <span class="custom-control-description">Masters</span>
                                         </label>
                                     </div>
+
+                                    <div class="col">
+                                        <label class="custom-control custom-checkbox custom-control-inline">
+                                            <input type="checkbox" id="display-recent-column-hit-catcher" class="custom-control-input">
+                                            <span class="custom-control-indicator"></span>
+                                            <span class="custom-control-description">Hit Catcher</span>
+                                        </label>
+                                    </div>
                                 </div>
 
                                 <div class="row mb-3">
@@ -772,6 +783,14 @@
                                             <span class="custom-control-description">Masters</span>
                                         </label>
                                     </div>
+
+                                    <div class="col">
+                                        <label class="custom-control custom-checkbox custom-control-inline">
+                                            <input type="checkbox" id="display-logged-column-hit-catcher" class="custom-control-input">
+                                            <span class="custom-control-indicator"></span>
+                                            <span class="custom-control-description">Hit Catcher</span>
+                                        </label>
+                                    </div>
                                 </div>
 
                                 <div class="row mb-3">
@@ -826,6 +845,14 @@
                                             <input type="checkbox" id="display-included-column-masters" class="custom-control-input">
                                             <span class="custom-control-indicator"></span>
                                             <span class="custom-control-description">Masters</span>
+                                        </label>
+                                    </div>
+
+                                    <div class="col">
+                                        <label class="custom-control custom-checkbox custom-control-inline">
+                                            <input type="checkbox" id="display-included-column-hit-catcher" class="custom-control-input">
+                                            <span class="custom-control-indicator"></span>
+                                            <span class="custom-control-description">Hit Catcher</span>
                                         </label>
                                     </div>
                                 </div>

--- a/hit-finder/hit-finder.js
+++ b/hit-finder/hit-finder.js
@@ -306,7 +306,6 @@ function finderProcess() {
       once.className = `btn btn-sm btn-primary px-2 py-0 hit-catcher`;
       once.dataset.key = hit.hit_set_id;
       once.dataset.name = `once`;
-      once.style.fontFamily = `"Lucida Console", Monaco, monospace`;
       once.textContent = `O`;
       hitCatcherContainer.appendChild(once);
 
@@ -315,7 +314,6 @@ function finderProcess() {
       panda.className = `btn btn-sm btn-primary px-2 py-0 hit-catcher`;
       panda.dataset.key = hit.hit_set_id;
       panda.dataset.name = `panda`;
-      panda.style.fontFamily = `"Lucida Console", Monaco, monospace`;
       panda.textContent = `P`;
       hitCatcherContainer.appendChild(panda);
 
@@ -944,30 +942,56 @@ $(`[data-toggle="tooltip"]`).tooltip({
   },
 });
 
-$(`body`).on(`click`, `.hit-catcher`, (event) => {
-  const key = event.target.dataset.key;
-  const once = event.target.dataset.name === `once` ? true : false;
-  const hit = finderDB[key];
-
-  chrome.runtime.sendMessage({
-    hitCatcher: {
-      id: key,
-      name: ``,
-      once: once,
-      sound: once,
-      project: {
-        requester_name: hit.requester_name,
-        requester_id: hit.requester_id,
-        title: hit.title,
-        hit_set_id: hit.hit_set_id,
-        monetary_reward: {
-          amount_in_dollars: hit.monetary_reward.amount_in_dollars
-        },
-        assignment_duration_in_seconds: hit.assignment_duration_in_seconds,
-        project_requirements: hit.project_requirements
+$(`body`).on(`click`, `.hit-catcher`, async (event) => {
+  const opened = await new Promise(resolve =>
+    chrome.runtime.sendMessage({ hitCatcher: `open` }, (open) => {
+      const err = chrome.runtime.lastError;
+      if (err) {
+        alert(`Hit Catcher does not appear to be running.`);
+      } else {
+        resolve(open);
       }
+    })
+  );
+
+  if (opened) {
+    const key = event.target.dataset.key;
+    const once = event.target.dataset.name === `once` ? true : false;
+    const hit = finderDB[key];
+
+    chrome.runtime.sendMessage({
+      hitCatcher: {
+        id: key,
+        name: ``,
+        once: once,
+        sound: once,
+        project: {
+          requester_name: hit.requester_name,
+          requester_id: hit.requester_id,
+          title: hit.title,
+          hit_set_id: hit.hit_set_id,
+          monetary_reward: {
+            amount_in_dollars: hit.monetary_reward.amount_in_dollars
+          },
+          assignment_duration_in_seconds: hit.assignment_duration_in_seconds,
+          project_requirements: hit.project_requirements
+        }
+      }
+    });
+
+    const elem = once ? 0 : 1;
+
+    const includedRow = document.getElementById(`included-${hit.hit_set_id}`);
+    if (includedRow) {
+      includedRow.children[7].firstChild.children[elem].classList.add(`bg-secondary`);
     }
-  });
+
+    document.getElementById(`recent-${hit.hit_set_id}`).children[7]
+      .firstChild.children[elem].classList.add(`bg-secondary`);
+
+    document.getElementById(`logged-${hit.hit_set_id}`).children[7]
+      .firstChild.children[elem].classList.add(`bg-secondary`);
+  }
 });
 
 $(`#block-list-add-modal`).on(`show.bs.modal`, (event) => {

--- a/hit-finder/hit-finder.js
+++ b/hit-finder/hit-finder.js
@@ -293,6 +293,32 @@ function finderProcess() {
           : `N`;
       row.appendChild(masters);
 
+      const hitCatcher = document.createElement(`td`);
+      hitCatcher.className = `text-center w-1`;
+      row.appendChild(hitCatcher);
+
+      const hitCatcherContainer = document.createElement(`div`);
+      hitCatcherContainer.className = `btn-group`;
+      hitCatcher.appendChild(hitCatcherContainer);
+
+      const once = document.createElement(`button`);
+      once.type = `button`;
+      once.className = `btn btn-sm btn-primary px-2 py-0 hit-catcher`;
+      once.dataset.key = hit.hit_set_id;
+      once.dataset.name = `once`;
+      once.style.fontFamily = `"Lucida Console", Monaco, monospace`;
+      once.textContent = `O`;
+      hitCatcherContainer.appendChild(once);
+
+      const panda = document.createElement(`button`);
+      panda.type = `button`;
+      panda.className = `btn btn-sm btn-primary px-2 py-0 hit-catcher`;
+      panda.dataset.key = hit.hit_set_id;
+      panda.dataset.name = `panda`;
+      panda.style.fontFamily = `"Lucida Console", Monaco, monospace`;
+      panda.textContent = `P`;
+      hitCatcherContainer.appendChild(panda);
+
       const recentRow = toggleColumns(row.cloneNode(true), `recent`);
       recentRow.id = `recent-${hit.hit_set_id}`;
 
@@ -683,6 +709,7 @@ function toggleColumns() {
   element.children[4].style.display = storage.hitFinder[`display-${type}-column-available`] ? `` : `none`;
   element.children[5].style.display = storage.hitFinder[`display-${type}-column-reward`] ? `` : `none`;
   element.children[6].style.display = storage.hitFinder[`display-${type}-column-masters`] ? `` : `none`;
+  element.children[7].style.display = storage.hitFinder[`display-${type}-column-hit-catcher`] ? `` : `none`;
 
   return element;
 }
@@ -915,6 +942,32 @@ $(`[data-toggle="tooltip"]`).tooltip({
   delay: {
     show: 500,
   },
+});
+
+$(`body`).on(`click`, `.hit-catcher`, (event) => {
+  const key = event.target.dataset.key;
+  const once = event.target.dataset.name === `once` ? true : false;
+  const hit = finderDB[key];
+
+  chrome.runtime.sendMessage({
+    hitCatcher: {
+      id: key,
+      name: ``,
+      once: once,
+      sound: once,
+      project: {
+        requester_name: hit.requester_name,
+        requester_id: hit.requester_id,
+        title: hit.title,
+        hit_set_id: hit.hit_set_id,
+        monetary_reward: {
+          amount_in_dollars: hit.monetary_reward.amount_in_dollars
+        },
+        assignment_duration_in_seconds: hit.assignment_duration_in_seconds,
+        project_requirements: hit.project_requirements
+      }
+    }
+  });
 });
 
 $(`#block-list-add-modal`).on(`show.bs.modal`, (event) => {


### PR DESCRIPTION
This pull request adds once and panda buttons to each HIT in HIT Finder that will send the HIT to HIT Catcher. This allows users to setup watchers from HIT Finder without visiting the MTurk website or having to right click and navigate menus. All of the data from the HIT will be added to the watcher as well as give the the watcher a recognizable name. From the name, users can tell what the watcher is looking for even before it catches a HIT instead of seeing the HIT ID as the name before a HIT is caught.

![HC-buttons](https://user-images.githubusercontent.com/13501366/57740337-fc27cd80-767c-11e9-9eb7-d8ccea2ae5fe.png)
