### PR TITLE
Fix issue where HC buttons on HF would not change color after being clicked

### DIFF
--- a/hit-finder/hit-finder.js
+++ b/hit-finder/hit-finder.js
@@ -983,14 +983,17 @@ $(`body`).on(`click`, `.hit-catcher`, async (event) => {
 
     const includedRow = document.getElementById(`included-${hit.hit_set_id}`);
     if (includedRow) {
-      includedRow.children[7].firstChild.children[elem].classList.add(`bg-secondary`);
+      includedRow.children[7].firstChild.children[elem].classList
+        .replace(`btn-primary`, `btn-secondary`);
     }
 
-    document.getElementById(`recent-${hit.hit_set_id}`).children[7]
-      .firstChild.children[elem].classList.add(`bg-secondary`);
+    document.getElementById(`recent-${hit.hit_set_id}`)
+      .children[7].firstChild.children[elem].classList
+      .replace(`btn-primary`, `btn-secondary`);
 
-    document.getElementById(`logged-${hit.hit_set_id}`).children[7]
-      .firstChild.children[elem].classList.add(`bg-secondary`);
+    const loggedClassList = document.getElementById(`logged-${hit.hit_set_id}`)
+      .children[7].firstChild.children[elem].classList
+      .replace(`btn-primary`, `btn-secondary`);
   }
 });
 


### PR DESCRIPTION
The HIT Catcher buttons on HIT Finder would not change color after being clicked for some users. This change should fix that issue.

Since this is just a cosmetics change it can probably wait to be pushed out until the next update.